### PR TITLE
Fix resume parsing polling timeout

### DIFF
--- a/src/app/pages/recruiter-workflow-candidate/recruiter-workflow-candidate.component.ts
+++ b/src/app/pages/recruiter-workflow-candidate/recruiter-workflow-candidate.component.ts
@@ -986,7 +986,7 @@ export class RecruiterWorkflowCandidate implements OnInit, OnDestroy {
     this.pollingService.poll(
       () => this.candidateService.checkResumeStatus(stagingId),
       3000, // 3 seconds interval
-      20    // Max 20 attempts (60 seconds total)
+      60000 // Max 20 attempts (60 seconds total)
     ).pipe(
       takeWhile((res: any) => {
         // Continue polling if status is PENDING or PROCESSING


### PR DESCRIPTION
Corrected the `startPollingResume` call in `RecruiterWorkflowCandidate.ts` to pass `60000` ms (60 seconds) as the timeout duration instead of `20` (which was intended as the attempt count but interpreted as duration). This fixes the issue where resume parsing would hang indefinitely on the frontend without making any API calls.

---
*PR created automatically by Jules for task [8886908475098212597](https://jules.google.com/task/8886908475098212597) started by @pprashanth65*